### PR TITLE
Revert "Update KDE runtime to 6.4"

### DIFF
--- a/io.github.martinrotter.rssguardlite.yml
+++ b/io.github.martinrotter.rssguardlite.yml
@@ -1,6 +1,6 @@
 id: io.github.martinrotter.rssguardlite
 runtime: org.kde.Platform
-runtime-version: '6.4'
+runtime-version: '6.3'
 sdk: org.kde.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.node16
@@ -16,6 +16,22 @@ finish-args:
   - --talk-name=org.kde.StatusNotifierWatcher
   - --talk-name=org.freedesktop.Notifications
 modules:
+  # TODO: Remove the following module once we update to the 6.4 SDK.
+  # See also: https://invent.kde.org/packaging/flatpak-kde-runtime/-/issues/26
+  - name: qt6-core5compat
+    buildsystem: cmake-ninja
+    builddir: true
+    sources:
+      - type: archive
+        url: https://download.qt.io/official_releases/qt/6.3/6.3.2/submodules/qt5compat-everywhere-src-6.3.2.tar.xz
+        sha256: 91a3ac0f3f87e4103afa5834ccbecff9374daf716fab362d0c5e2d6ab98560cc
+    post-install:
+      - ln -sr /app/lib/${FLATPAK_ARCH}-linux-gnu/libQt6Core5Compat.so* -t /app/lib
+    cleanup:
+      - /include
+      - /mkspecs
+      - /modules
+
   - name: rssguard
     buildsystem: cmake-ninja
     config-opts:


### PR DESCRIPTION
Qt 6.4.2 might temporarily freeze the GUI while fetching feeds, so go back to 6.3 for now.

This reverts commit 7dd049a317ac3cb155349116216bcd918b297fb8.