### PR TITLE
Update KDE runtime to 6.4

### DIFF
--- a/io.github.martinrotter.rssguardlite.yml
+++ b/io.github.martinrotter.rssguardlite.yml
@@ -1,6 +1,6 @@
 id: io.github.martinrotter.rssguardlite
 runtime: org.kde.Platform
-runtime-version: '6.3'
+runtime-version: '6.4'
 sdk: org.kde.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.node16
@@ -16,22 +16,6 @@ finish-args:
   - --talk-name=org.kde.StatusNotifierWatcher
   - --talk-name=org.freedesktop.Notifications
 modules:
-  # TODO: Remove the following module once we update to the 6.4 SDK.
-  # See also: https://invent.kde.org/packaging/flatpak-kde-runtime/-/issues/26
-  - name: qt6-core5compat
-    buildsystem: cmake-ninja
-    builddir: true
-    sources:
-      - type: archive
-        url: https://download.qt.io/official_releases/qt/6.3/6.3.2/submodules/qt5compat-everywhere-src-6.3.2.tar.xz
-        sha256: 91a3ac0f3f87e4103afa5834ccbecff9374daf716fab362d0c5e2d6ab98560cc
-    post-install:
-      - ln -sr /app/lib/${FLATPAK_ARCH}-linux-gnu/libQt6Core5Compat.so* -t /app/lib
-    cleanup:
-      - /include
-      - /mkspecs
-      - /modules
-
   - name: rssguard
     buildsystem: cmake-ninja
     config-opts:


### PR DESCRIPTION
I've tried this before, but I had to [revert it](https://github.com/flathub/io.github.martinrotter.rssguardlite/pull/4) because RSS Guard would temporarily freeze while syncing feeds.

But back then the KDE runtime was using Qt 6.4.2, while now it uses 6.4.3, so I want to test if the issue is gone.