### PR TITLE
Downgrade KDE runtime to 5.15-22.08

### DIFF
--- a/io.github.martinrotter.rssguardlite.yml
+++ b/io.github.martinrotter.rssguardlite.yml
@@ -1,6 +1,6 @@
 id: io.github.martinrotter.rssguardlite
 runtime: org.kde.Platform
-runtime-version: '6.4'
+runtime-version: '5.15-22.08'
 sdk: org.kde.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.node16
@@ -19,7 +19,7 @@ modules:
   - name: rssguard
     buildsystem: cmake-ninja
     config-opts:
-      - -DBUILD_WITH_QT6=ON
+      - -DBUILD_WITH_QT6=OFF
       - -DFORCE_BUNDLE_ICONS=ON
       - -DIS_FLATPAK_BUILD=ON
       - -DNO_UPDATE_CHECK=ON


### PR DESCRIPTION
If I remember correctly, the only real reason we were using the KDE 6 runtime in the first place, was because of a bad file descriptor leak that would happen whenever we hovered the mouse cursor over any clickable URLs in the article viewer panel.

That issue can still be reproduced with the [official v4.4.3 AppImage](https://github.com/martinrotter/rssguard/releases/download/4.3.4/rssguard-4.3.4-fb2c439b-nowebengine-linux64.AppImage), which still bundles Qt 5.15.4 from Ubuntu 20.04 repositories:

https://github.com/flathub/io.github.martinrotter.rssguardlite/assets/626206/a9a099bd-0af5-41b4-97cb-178d0facd452

The command I used in the video to count open file descriptors:

```
watch -n.1 'bash -c "echo fd count: ±$(ls -l /proc/$(pidof rssguard)/fd | wc -l)"'
```

However, because the KDE 5.15 runtime for Flatpak uses a [more recent version of Qt 5](https://invent.kde.org/packaging/flatpak-kde-runtime/-/blob/9eebd292e0fae04d9c09ac4b1095acf63d4a997f/org.kde.Sdk.json.in#L171-175) (currently 5.15.9), I'm opening this pull request to test if this descriptor leak issue has been fixed.

Some other unrelated benefits of the downgrade:

- The Breeze theme from KDE does not currently work with Qt 6, so the default Fusion theme is chosen, which makes RSS Guard look a little out of place on a KDE Plasma desktop
- The 5.15-22.08 runtime is currently _much_ more popular than any of the 6.x runtimes:
  - Apps on Flathub using the `5.15-22.08` runtime:

    ```
    $ flatpak remote-ls --app-runtime=org.kde.Platform/x86_64/5.15-22.08 flathub | wc -l
    317
    ```
  - Apps on Flathub using the `6.4` runtime (currently the most popular from the `6.x` series):
    ```
    $ flatpak remote-ls --app-runtime=org.kde.Platform/x86_64/6.4 flathub | wc -l
    54
    ```