### PR TITLE
Set a default file name for the sources tarball

### DIFF
--- a/io.github.martinrotter.rssguardlite.yml
+++ b/io.github.martinrotter.rssguardlite.yml
@@ -28,7 +28,7 @@ modules:
       - -DUSE_WEBENGINE=OFF
     sources:
       - type: archive
-        archive-type: tar-gzip
+        dest-filename: rssguard.tar.gz
         url: https://api.github.com/repos/martinrotter/rssguard/tarball/4.5.0
         sha256: ffd2631c293e5ca21642cfce6136876762e54db7bdda779d3ec9153d809cc422
         x-checker-data:


### PR DESCRIPTION
This is done just to prevent the [flatpak-external-data-checker bot](https://github.com/flathub/flatpak-external-data-checker/) from creating commits with non-descriptive titles.

Before:

"Update 4.5.0 to 4.6.0"

After:

"Update rssguard.tar.gz to 4.6.0"