### PR TITLE
Update NodeJS from v16 to v18

### DIFF
--- a/io.github.martinrotter.rssguardlite.yml
+++ b/io.github.martinrotter.rssguardlite.yml
@@ -3,7 +3,7 @@ runtime: org.kde.Platform
 runtime-version: 5.15-22.08
 sdk: org.kde.Sdk
 sdk-extensions:
-  - org.freedesktop.Sdk.Extension.node16
+  - org.freedesktop.Sdk.Extension.node18
 command: rssguard
 
 finish-args:
@@ -42,12 +42,12 @@ modules:
     cleanup:
       - /include
 
-  - name: nodejs_and_npm
+  - name: nodejs-and-npm
     buildsystem: simple
     build-commands:
-      - mkdir -p /app/bin /app/lib
-      - cp -a /usr/lib/sdk/node16/bin/{node,npm} /app/bin
-      - cp -a /usr/lib/sdk/node16/lib/* /app/lib
+      - mkdir -p /app/{bin,lib}
+      - cp -a /usr/lib/sdk/node18/bin/{node,npm} /app/bin
+      - cp -a /usr/lib/sdk/node18/lib/* /app/lib
       - rm -r /app/lib/node_modules/npm/{docs,man}
 
   - name: clang-format


### PR DESCRIPTION
v16 has reached end of life in 2023-09-11:

https://nodejs.dev/en/about/releases/

This upgrades to the next LTS release.

Closes #16