### PR TITLE
Downgrade KDE runtime to 6.6

### DIFF
--- a/io.github.martinrotter.rssguardlite.yml
+++ b/io.github.martinrotter.rssguardlite.yml
@@ -1,6 +1,6 @@
 id: io.github.martinrotter.rssguardlite
 runtime: org.kde.Platform
-runtime-version: '6.7'
+runtime-version: '6.6'
 sdk: org.kde.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.node18


### PR DESCRIPTION
Downgrade KDE runtime to 6.6

Qt 6.7.0 seems to be making the main window "invisible" on some Wayland compositors (e.g. [GNOME's Mutter](https://github.com/flathub/io.github.martinrotter.rssguardlite/issues/41), and maybe [Hyprland](https://github.com/martinrotter/rssguard/issues/1370)?), so let's stay on 6.6 until we find a workaround, or until this gets dealt with in Qt.

Fixes #41