### PR TITLE
Update KDE runtime to 6.9 and import patch to fix crash on exit

### DIFF
--- a/io.github.martinrotter.rssguardlite.yml
+++ b/io.github.martinrotter.rssguardlite.yml
@@ -1,6 +1,6 @@
 id: io.github.martinrotter.rssguardlite
 runtime: org.kde.Platform
-runtime-version: '6.8'
+runtime-version: '6.9'
 sdk: org.kde.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.node20

--- a/io.github.martinrotter.rssguardlite.yml
+++ b/io.github.martinrotter.rssguardlite.yml
@@ -69,5 +69,7 @@ modules:
           url: https://api.github.com/repos/martinrotter/rssguard/releases/latest
           version-query: .tag_name
           url-query: .tarball_url
+      - type: patch
+        path: patches/0001-fix-long-standing-bug-1654.patch
     cleanup:
       - /include

--- a/patches/0001-fix-long-standing-bug-1654.patch
+++ b/patches/0001-fix-long-standing-bug-1654.patch
@@ -1,0 +1,27 @@
+From 45f8b159261de20f16e69701f16fed7f29100480 Mon Sep 17 00:00:00 2001
+From: Martin Rotter <rotter.martinos@gmail.com>
+Date: Tue, 24 Jun 2025 07:21:49 +0200
+Subject: [PATCH] fix long-standing bug #1654
+
+---
+ .../gui/webviewers/qtextbrowser/textbrowserviewer.cpp      | 7 +++----
+ 1 file changed, 3 insertions(+), 4 deletions(-)
+
+diff --git a/src/librssguard/gui/webviewers/qtextbrowser/textbrowserviewer.cpp b/src/librssguard/gui/webviewers/qtextbrowser/textbrowserviewer.cpp
+index dd21178a8..59774dd48 100644
+--- a/src/librssguard/gui/webviewers/qtextbrowser/textbrowserviewer.cpp
++++ b/src/librssguard/gui/webviewers/qtextbrowser/textbrowserviewer.cpp
+@@ -56,10 +56,9 @@ TextBrowserViewer::TextBrowserViewer(QWidget* parent)
+ }
+ 
+ TextBrowserViewer::~TextBrowserViewer() {
+-  if (m_resourceDownloaderThread->isRunning()) {
+-    m_resourceDownloaderThread->quit();
+-  }
+-
++  m_resourceDownloaderThread->quit();
++  m_resourceDownloaderThread->wait();
++  m_resourceDownloaderThread->deleteLater();
+   m_resourceDownloader->deleteLater();
+ }
+ 


### PR DESCRIPTION
This PR:

- Imports [a patch](https://github.com/martinrotter/rssguard/commit/45f8b159261de20f16e69701f16fed7f29100480) from the [4.x branch](https://github.com/martinrotter/rssguard/tree/4.x) that fixes [a random crash](https://redirect.github.com/martinrotter/rssguard/issues/1654) on exit
- Updates the KDE runtime (and Qt libs) to version 6.9

Closes #78