### PR TITLE
Revert "Update KDE runtime to 6.9"

### DIFF
--- a/io.github.martinrotter.rssguardlite.yml
+++ b/io.github.martinrotter.rssguardlite.yml
@@ -1,6 +1,6 @@
 id: io.github.martinrotter.rssguardlite
 runtime: org.kde.Platform
-runtime-version: '6.9'
+runtime-version: '6.8'
 sdk: org.kde.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.node20


### PR DESCRIPTION
Something in this update broke QtWebEngine rendering in some configurations:

https://redirect.github.com/martinrotter/rssguard/issues/1832
https://redirect.github.com/martinrotter/rssguard/issues/1826

Go back to 6.8 for the time being.

This reverts commit 3d4a0ac8c9a2eed3fb3c80704a8c3a5af7216972.