### PR TITLE
Patch: Update `@ghostery/adblocker` npm package to its latest version

### DIFF
--- a/io.github.martinrotter.rssguardlite.yml
+++ b/io.github.martinrotter.rssguardlite.yml
@@ -71,6 +71,8 @@ modules:
           url-query: .tarball_url
       # https://github.com/martinrotter/rssguard/commit/7ec01c8dbafe45b55f133b0fd89384e8cb953abe
       - type: patch
-        path: patches/0001-Set-a-fixed-release-date.patch
+        paths:
+          - patches/0001-Set-a-fixed-release-date.patch
+          - patches/Update-ghostery-adblocker-version.patch
     cleanup:
       - /include

--- a/patches/Update-ghostery-adblocker-version.patch
+++ b/patches/Update-ghostery-adblocker-version.patch
@@ -1,0 +1,13 @@
+diff --git a/src/librssguard/network-web/adblock/adblockmanager.h b/src/librssguard/network-web/adblock/adblockmanager.h
+index 3b1214beb..449b49cd1 100644
+--- a/src/librssguard/network-web/adblock/adblockmanager.h
++++ b/src/librssguard/network-web/adblock/adblockmanager.h
+@@ -10,7 +10,7 @@
+ #include <QProcess>
+ 
+ #define CLIQZ_ADBLOCKED_PACKAGE "@ghostery/adblocker"
+-#define CLIQZ_ADBLOCKED_VERSION "2.5.1"
++#define CLIQZ_ADBLOCKED_VERSION "2.12.5"
+ 
+ class QUrl;
+ class AdblockRequestInfo;


### PR DESCRIPTION
This fixes the AdBlocker not being able to initialize with the default filters:

```
time="  1429.245" type="debug" -> nodejs: Packages '@ghostery/adblocker@2.5.1' are up-to-date.
time="  1429.249" type="debug" -> network: Settings of BaseNetworkAccessManager loaded.
time="  1429.410" type="debug" -> network: URLS
Request: https://secure.fanboy.co.nz/easylist.txt
Response: https://secure.fanboy.co.nz/easylist.txt
time="  1429.410" type="debug" -> network: Destroying Downloader instance.
time="  1429.410" type="debug" -> network: Destroying SilentNetworkAccessManager instance.
time="  1429.415" type="debug" -> adblock: Downloaded filter list from 'https://secure.fanboy.co.nz/easylist.txt'.
time="  1429.415" type="debug" -> network: Settings of BaseNetworkAccessManager loaded.
time="  1429.538" type="debug" -> network: URLS
Request: https://secure.fanboy.co.nz/easyprivacy.txt
Response: https://secure.fanboy.co.nz/easyprivacy.txt
time="  1429.538" type="debug" -> network: Destroying Downloader instance.
time="  1429.538" type="debug" -> network: Destroying SilentNetworkAccessManager instance.
time="  1429.543" type="debug" -> adblock: Downloaded filter list from 'https://secure.fanboy.co.nz/easyprivacy.txt'.
time="  1429.543" type="debug" -> network: Settings of BaseNetworkAccessManager loaded.
time="  1429.651" type="debug" -> network: URLS
Request: https://secure.fanboy.co.nz/fanboy-social.txt
Response: https://secure.fanboy.co.nz/fanboy-social.txt
time="  1429.651" type="debug" -> network: Destroying Downloader instance.
time="  1429.651" type="debug" -> network: Destroying SilentNetworkAccessManager instance.
time="  1429.651" type="debug" -> adblock: Downloaded filter list from 'https://secure.fanboy.co.nz/fanboy-social.txt'.
time="  1429.660" type="debug" -> adblock: Attempting to start AdBlock server.
/home/gui/.var/app/io.github.martinrotter.rssguardlite/config/RSS Guard 4/node-packages-linux/node_modules/@ghostery/adblocker/dist/commonjs/filters/cosmetic.js:257
                if ((0, adblocker_extended_selectors_1.isPureHasSelector)(selector)) {
                                                                         ^

TypeError: (0 , adblocker_extended_selectors_1.isPureHasSelector) is not a function
    at CosmeticFilter.parse (/home/gui/.var/app/io.github.martinrotter.rssguardlite/config/RSS Guard 4/node-packages-linux/node_modules/@ghostery/adblocker/dist/commonjs/filters/cosmetic.js:257:74)
    at parseFilters (/home/gui/.var/app/io.github.martinrotter.rssguardlite/config/RSS Guard 4/node-packages-linux/node_modules/@ghostery/adblocker/dist/commonjs/lists.js:231:50)
    at FilterEngine.parse (/home/gui/.var/app/io.github.martinrotter.rssguardlite/config/RSS Guard 4/node-packages-linux/node_modules/@ghostery/adblocker/dist/commonjs/engine/engine.js:258:44)
    at Object.<anonymous> (/tmp/adblock-server.js:28:38)
    at Module._compile (node:internal/modules/cjs/loader:1521:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1623:10)
    at Module.load (node:internal/modules/cjs/loader:1266:32)
    at Module._load (node:internal/modules/cjs/loader:1091:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:164:12)
    at node:internal/main/run_main_module:28:49

Node.js v20.19.5
time="  1430.359" type="critical" -> adblock: Process exited with exit code '1' so check application log for more details.
```

My guess is that version 2.5.1 is incompatible with current filter syntax.

See also:

https://github.com/flathub/io.github.martinrotter.rssguard/pull/181
https://github.com/martinrotter/rssguard/discussions/1871