### PR TITLE
Mark lite build as end-of-life

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+  "end-of-life": "The lite version has been removed in version 5.0.0. Please switch to the regular version."
+}


### PR DESCRIPTION
Version 5.0.0 removed the "lite build" option entirely, because the "regular build" switched from QtWebEngine to litehtml which, as the name implies, is much lighter than QtWebEngine.

This essentially made the "lite build" redundant, and so it was removed.

Check out the release page for more details:

https://github.com/martinrotter/rssguard/releases/tag/5.0.0

Closes #96